### PR TITLE
Update views.py

### DIFF
--- a/tg_react/api/accounts/views.py
+++ b/tg_react/api/accounts/views.py
@@ -16,7 +16,6 @@ from .serializers import (AuthenticationSerializer, UserDetailsSerializer, Signu
 
 # for email notifications
 from django.template.loader import get_template
-from django.template import Context
 
 from tg_react.settings import get_password_recovery_url, get_post_login_handler, get_post_logout_handler
 
@@ -192,7 +191,7 @@ class ForgotPassword(APIView):
         confirm_reset_url = settings.SITE_URL + path
 
         subject = _("Password restore")
-        context = Context({'user': user, 'confirm_reset_url': confirm_reset_url})
+        context = {'user': user, 'confirm_reset_url': confirm_reset_url}
         text_content = get_template('emails/password_reset.txt').render(context)
         html_content = get_template('emails/password_reset.html').render(context)
 


### PR DESCRIPTION
Apparently the Context class does not work any more in Django 1.11.11 and This Context class fails when rendering the template with following error:

```
django_1    |   File "/usr/local/lib/python3.6/site-packages/tg_react/api/accounts/views.py", line 206, in post
django_1    |     self.send_email_notification(serializer.user, serializer.validated_data['uid_and_token_b64'])
django_1    |   File "/usr/local/lib/python3.6/site-packages/tg_react/api/accounts/views.py", line 196, in send_email_notification
django_1    |     text_content = get_template('emails/password_reset.txt').render(context)
django_1    |   File "/usr/local/lib/python3.6/site-packages/django/template/backends/django.py", line 64, in render
django_1    |     context = make_context(context, request, autoescape=self.backend.engine.autoescape)
django_1    |   File "/usr/local/lib/python3.6/site-packages/django/template/context.py", line 287, in make_context
django_1    |     raise TypeError('context must be a dict rather than %s.' % context.__class__.__name__)
django_1    | TypeError: context must be a dict rather than Context
```
