### PR TITLE
User signup skipped fields, case-insensitive emails for user logins

### DIFF
--- a/tg_react/api/accounts/serializers.py
+++ b/tg_react/api/accounts/serializers.py
@@ -9,7 +9,8 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.translation import ugettext as _
 
-from tg_react.settings import exclude_fields_from_user_details, get_user_signup_fields, user_extra_fields
+from tg_react.settings import exclude_fields_from_user_details, get_user_signup_fields, user_extra_fields, \
+    get_email_case_sensitive
 
 
 class UserDetailsSerializer(serializers.ModelSerializer):
@@ -29,7 +30,13 @@ class UserDetailsSerializer(serializers.ModelSerializer):
         }
 
     def validate_email(self, data):
-        if get_user_model().objects.filter(email=data).exists() and self.instance.email != data:
+        current_email = self.instance.email
+
+        if not get_email_case_sensitive():
+            data = data.lower()
+            current_email = current_email.lower()
+
+        if get_user_model().objects.filter(email=data).exists() and current_email != data:
             raise serializers.ValidationError(_("User with this e-mail address already exists."))
 
         return data
@@ -60,6 +67,10 @@ class AuthenticationSerializer(serializers.Serializer):
 
         if all(credentials.values()):
             from django.contrib.auth import authenticate
+
+            if not get_email_case_sensitive():
+                credentials['email'] = credentials['email'].lower()
+
             user = authenticate(**credentials)
 
             if user:
@@ -128,6 +139,9 @@ class SignupSerializer(serializers.Serializer):
                 self._declared_fields[model_field.name] = mapping[model_field](**field_kwargs)
 
     def validate_email(self, data):
+        if not get_email_case_sensitive():
+            data = data.lower()
+
         if get_user_model().objects.filter(email=data).exists():
             raise serializers.ValidationError(_("User with this e-mail address already exists."))
 
@@ -144,6 +158,9 @@ class ForgotPasswordSerializer(serializers.Serializer):
 
     def validate_email(self, email):
         user_model = get_user_model()
+
+        if not get_email_case_sensitive():
+            email = email.lower()
 
         try:
             self.user = user_model.objects.get(email=email)

--- a/tg_react/api/accounts/serializers.py
+++ b/tg_react/api/accounts/serializers.py
@@ -24,9 +24,12 @@ class UserDetailsSerializer(serializers.ModelSerializer):
 
         extra_kwargs = {
             'password': {'write_only': True},
-            'is_staff': {'read_only': True},
+            'id': {'read_only': True},
             'is_active': {'read_only': True},
+            'is_staff': {'read_only': True},
+            'is_superuser': {'read_only': True},
             'date_joined': {'read_only': True},
+            'last_login': {'read_only': True},
         }
 
     def validate_email(self, data):

--- a/tg_react/api/accounts/views.py
+++ b/tg_react/api/accounts/views.py
@@ -18,7 +18,8 @@ from .serializers import (AuthenticationSerializer, UserDetailsSerializer, Signu
 from django.template.loader import get_template
 from django.template import Context
 
-from tg_react.settings import get_password_recovery_url, get_post_login_handler, get_post_logout_handler
+from tg_react.settings import get_password_recovery_url, get_post_login_handler, get_post_logout_handler, \
+    get_signup_skipped_fields
 
 
 def do_login(request, user):
@@ -155,6 +156,9 @@ class SignUpView(APIView):
         if serializer.is_valid():
             data = serializer.validated_data.copy()
             password = data.pop('password', None)
+
+            for skipped_field in get_signup_skipped_fields():
+                data.pop(skipped_field, None)
 
             user = get_user_model()(**data)
             user.set_password(password)

--- a/tg_react/settings.py
+++ b/tg_react/settings.py
@@ -12,6 +12,14 @@ def get_user_signup_fields():
     return getattr(settings, 'TGR_USER_SIGNUP_FIELDS', ['name', ])
 
 
+def get_signup_skipped_fields():
+    return getattr(settings, 'TGR_USER_SIGNUP_SKIPPED_FIELDS', [])
+
+
+def get_email_case_sensitive():
+    return getattr(settings, 'TGR_EMAIL_CASE_SENSITIVE', True)  # True by default to maintain compatibility
+
+
 def exclude_fields_from_user_details():
     return getattr(settings, 'TGR_EXCLUDED_USER_FIELDS', [])
 

--- a/tg_react/settings.py
+++ b/tg_react/settings.py
@@ -8,12 +8,17 @@ except ImportError:
     from django.utils.module_loading import import_by_path as import_string
 
 
+# fields unconditionally excluded from user signup data
+USER_SIGNUP_SKIPPED_FIELDS = {'id', 'is_staff', 'is_superuser', 'is_active', 'date_joined', 'last_login'}
+
+
 def get_user_signup_fields():
     return getattr(settings, 'TGR_USER_SIGNUP_FIELDS', ['name', ])
 
 
 def get_signup_skipped_fields():
-    return getattr(settings, 'TGR_USER_SIGNUP_SKIPPED_FIELDS', [])
+    fields = getattr(settings, 'TGR_USER_SIGNUP_SKIPPED_FIELDS', [])
+    return USER_SIGNUP_SKIPPED_FIELDS.union(fields)
 
 
 def get_email_case_sensitive():


### PR DESCRIPTION
* Add configuration values for TGR_USER_SIGNUP_SKIPPED_FIELDS and TGR_EMAIL_CASE_SENSITIVE (defaults to True to maintain compatibility)
* Allow account serializers to use case-insensitive email when the setting is off